### PR TITLE
feat: allow pinning actions

### DIFF
--- a/src/action/ActionImpl.ts
+++ b/src/action/ActionImpl.ts
@@ -33,6 +33,7 @@ export class ActionImpl implements Action {
    */
   perform: Action["perform"];
   priority: number = Priority.NORMAL;
+  pinned: Action["pinned"];
 
   command?: Command;
 
@@ -57,6 +58,7 @@ export class ActionImpl implements Action {
       );
     // Backwards compatibility
     this.perform = this.command?.perform;
+    this.pinned = action.pinned ?? false;
 
     if (action.parent) {
       const parentActionImpl = options.store[action.parent];

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,7 @@ export type Action = {
   perform?: (currentActionImpl: ActionImpl) => any;
   parent?: ActionId;
   priority?: Priority;
+  pinned?: boolean; // pinned actions are never filtered out
 };
 
 export type ActionStore = Record<ActionId, ActionImpl>;


### PR DESCRIPTION
pinned actions are always visible, even if they don't match the search query